### PR TITLE
os.exit, variable names, printing all funcs

### DIFF
--- a/gtfobins/gtfobins.go
+++ b/gtfobins/gtfobins.go
@@ -3,8 +3,8 @@ package gtfobins
 import (
 	"fmt"
 	"io/ioutil"
-	"log"
 	"net/http"
+	"os"
 
 	"gopkg.in/yaml.v2"
 )
@@ -12,80 +12,87 @@ import (
 var exploit gtfoStruct
 
 func getExploit(name string) gtfoStruct {
-	url := fmt.Sprintf(baseURL, name)
+	url := baseURL + name + ".md"
 
 	resp, err := http.Get(url)
 	if err != nil {
-		log.Fatalf("Error fetching data : %s\n", err)
+		fmt.Println("Error fetching data:", err)
+		os.Exit(1)
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode != 200 {
+		fmt.Println("Queried binary not available!")
+		os.Exit(1)
+	}
+
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		log.Fatalf("Error reading data : %s\n", err)
+		fmt.Println("Error reading data:", err)
+		os.Exit(1)
 	}
 
 	var gtfoExploit gtfoStruct
 	err = yaml.Unmarshal(body, &gtfoExploit)
 	if err != nil {
-		log.Fatalf("Error parsing YAML file: %s\n", err)
+		fmt.Println("Error parsing YAML file:", err)
+		os.Exit(1)
 	}
 	return gtfoExploit
 }
 
-//returns formatted exploit
+// returns formatted exploit
 func exploitFormatter(funcArray []function, funcName string) string {
-	funcString := COLOR_CYAN + funcName + COLOR_RESET + "\n\n" + funcDesc[funcName] + "\n\n"
+	funcString := colorCyan + funcName + colorReset + "\n\n" + funcDesc[funcName] + "\n\n"
 
-	for _, s := range funcArray {
+	for i, s := range funcArray {
 
 		if s.Description != "" {
-			funcString += "Description :\n" + s.Description + "\n"
+			funcString += fmt.Sprintf("[%d] Description:\n%s\n", i+1, s.Description)
 		}
 		if s.Code != "" {
 			funcString += "Code :\n" + s.Code + "\n"
 		}
-		funcString += "\n"
 	}
-	return funcString
+	return funcString + "\n"
 }
 
-//Shell - returns formatted Shell exploit
+// Shell - returns formatted Shell exploit
 func Shell() string {
 	if exploit.Functions.Shell != nil {
-		return exploitFormatter(exploit.Functions.Shell, SHELL)
+		return exploitFormatter(exploit.Functions.Shell, shell)
 	}
 	return ""
 }
 
-//Command - returns formatted Command exploit
+// Command - returns formatted Command exploit
 func Command() string {
 	if exploit.Functions.Command != nil {
-		return exploitFormatter(exploit.Functions.Command, COMMAND)
+		return exploitFormatter(exploit.Functions.Command, cmd)
 	}
 	return ""
 }
 
-//ReverseShell - returns formatted ReverseShell exploit
+// ReverseShell - returns formatted ReverseShell exploit
 func ReverseShell() string {
 	if exploit.Functions.ReverseShell != nil {
-		return exploitFormatter(exploit.Functions.ReverseShell, R_SHELL)
+		return exploitFormatter(exploit.Functions.ReverseShell, revShell)
 	}
 	return ""
 }
 
-//NonInteractiveReverseShell - returns formatted NonInteractiveReverseShell exploit
+// NonInteractiveReverseShell - returns formatted NonInteractiveReverseShell exploit
 func NonInteractiveReverseShell() string {
 	if exploit.Functions.NonInteractiveReverseShell != nil {
-		return exploitFormatter(exploit.Functions.NonInteractiveReverseShell, NI_R_SHELL)
+		return exploitFormatter(exploit.Functions.NonInteractiveReverseShell, nonIntRevShell)
 	}
 	return ""
 }
 
-//BindShell - returns formatted BindShell exploit
+// BindShell - returns formatted BindShell exploit
 func BindShell() string {
 	if exploit.Functions.BindShell != nil {
-		return exploitFormatter(exploit.Functions.BindShell, B_SHELL)
+		return exploitFormatter(exploit.Functions.BindShell, bindShell)
 	}
 	return ""
 }
@@ -93,84 +100,84 @@ func BindShell() string {
 //NonInteractiveBindShell - returns formatted NonInteractiveBindShell exploit
 func NonInteractiveBindShell() string {
 	if exploit.Functions.NonInteractiveBindShell != nil {
-		return exploitFormatter(exploit.Functions.NonInteractiveBindShell, NI_B_SHELL)
+		return exploitFormatter(exploit.Functions.NonInteractiveBindShell, nonIntBindShell)
 	}
 	return ""
 }
 
-//FileUpload - returns formatted FileUpload exploit
+// FileUpload - returns formatted FileUpload exploit
 func FileUpload() string {
 	if exploit.Functions.FileUpload != nil {
-		return exploitFormatter(exploit.Functions.FileUpload, F_UPLOAD)
+		return exploitFormatter(exploit.Functions.FileUpload, fileUpload)
 	}
 	return ""
 }
 
-//FileDownload - returns formatted FileDownload exploit
+// FileDownload - returns formatted FileDownload exploit
 func FileDownload() string {
 	if exploit.Functions.FileDownload != nil {
-		return exploitFormatter(exploit.Functions.FileDownload, F_DOWNLOAD)
+		return exploitFormatter(exploit.Functions.FileDownload, fileDownload)
 	}
 	return ""
 }
 
-//FileWrite - returns formatted FileWrite exploit
+// FileWrite - returns formatted FileWrite exploit
 func FileWrite() string {
 	if exploit.Functions.FileWrite != nil {
-		return exploitFormatter(exploit.Functions.FileWrite, F_WRITE)
+		return exploitFormatter(exploit.Functions.FileWrite, fileWrite)
 	}
 	return ""
 }
 
-//FileRead - returns formatted FileRead exploit
+// FileRead - returns formatted FileRead exploit
 func FileRead() string {
 	if exploit.Functions.FileRead != nil {
-		return exploitFormatter(exploit.Functions.FileRead, F_READ)
+		return exploitFormatter(exploit.Functions.FileRead, fileRead)
 	}
 	return ""
 }
 
-//LibraryLoad - returns formatted LibraryLoad exploit
+// LibraryLoad - returns formatted LibraryLoad exploit
 func LibraryLoad() string {
 	if exploit.Functions.LibraryLoad != nil {
-		return exploitFormatter(exploit.Functions.LibraryLoad, LIBRARY_LOAD)
+		return exploitFormatter(exploit.Functions.LibraryLoad, libLoad)
 	}
 	return ""
 }
 
-//Suid  - returns formatted Suid  exploit
-func Suid() string {
-	if exploit.Functions.Suid != nil {
-		return exploitFormatter(exploit.Functions.Suid, SUID)
+// SUID - returns formatted Suid  exploit
+func SUID() string {
+	if exploit.Functions.SUID != nil {
+		return exploitFormatter(exploit.Functions.SUID, suid)
 	}
 	return ""
 }
 
-//Sudo - returns formatted Sudo exploit
+// Sudo - returns formatted Sudo exploit
 func Sudo() string {
 	if exploit.Functions.Sudo != nil {
-		return exploitFormatter(exploit.Functions.Sudo, SUDO)
+		return exploitFormatter(exploit.Functions.Sudo, sudo)
 	}
 	return ""
 }
 
-//Capabilities - returns formatted Capabilities exploit
+// Capabilities - returns formatted Capabilities exploit
 func Capabilities() string {
 	if exploit.Functions.Capabilities != nil {
-		return exploitFormatter(exploit.Functions.Capabilities, CAPABILITIES)
+		return exploitFormatter(exploit.Functions.Capabilities, capab)
 	}
 	return ""
 }
 
-//LimitedSuid - returns formatted LimitedSuid exploit
+// LimitedSuid - returns formatted LimitedSuid exploit
 func LimitedSuid() string {
 	if exploit.Functions.LimitedSuid != nil {
-		return exploitFormatter(exploit.Functions.LimitedSuid, LIM_SUID)
+		return exploitFormatter(exploit.Functions.LimitedSuid, limSUID)
 	}
 	return ""
 }
 
-//GtfobinMain - main function of gtfobins package
+// GtfobinMain - main function of gtfobins package
 func GtfobinMain(name string) {
 	exploit = getExploit(name)
 }

--- a/gtfobins/gtfobins_utils.go
+++ b/gtfobins/gtfobins_utils.go
@@ -1,32 +1,32 @@
 package gtfobins
 
 const (
-	COLOR_RESET  = "\033[0m"
-	COLOR_RED    = "\033[31m"
-	COLOR_GREEN  = "\033[32m"
-	COLOR_YELLOW = "\033[33m"
-	COLOR_BLUE   = "\033[34m"
-	COLOR_PURPLE = "\033[35m"
-	COLOR_CYAN   = "\033[36m"
-	COLOR_WHITE  = "\033[37m"
-	SHELL        = "Shell"
-	COMMAND      = "Command"
-	R_SHELL      = "Reverse Shell"
-	NI_R_SHELL   = "Non-Interactive Reverse Shell"
-	B_SHELL      = "Bind Shell"
-	NI_B_SHELL   = "Non-Interactive Bind Shell"
-	F_UPLOAD     = "File Upload"
-	F_DOWNLOAD   = "File Download"
-	F_WRITE      = "File Write"
-	F_READ       = "File Read"
-	LIBRARY_LOAD = "Library Load"
-	SUID         = "SUID"
-	SUDO         = "Sudo"
-	CAPABILITIES = "Capabilities"
-	LIM_SUID     = "Limited SUID"
+	colorReset      = "\033[0m"
+	colorRed        = "\033[31m"
+	colorGreen      = "\033[32m"
+	colorYellow     = "\033[33m"
+	colorBlue       = "\033[34m"
+	colorPurple     = "\033[35m"
+	colorCyan       = "\033[36m"
+	colorWhite      = "\033[37m"
+	shell           = "Shell"
+	cmd             = "Command"
+	revShell        = "Reverse Shell"
+	nonIntRevShell  = "Non-Interactive Reverse Shell"
+	bindShell       = "Bind Shell"
+	nonIntBindShell = "Non-Interactive Bind Shell"
+	fileUpload      = "File Upload"
+	fileDownload    = "File Download"
+	fileWrite       = "File Write"
+	fileRead        = "File Read"
+	libLoad         = "Library Load"
+	suid            = "SUID"
+	sudo            = "Sudo"
+	capab           = "Capabilities"
+	limSUID         = "Limited SUID"
 )
 
-var baseURL = "https://raw.githubusercontent.com/GTFOBins/GTFOBins.github.io/master/_gtfobins/%s.md"
+var baseURL = "https://raw.githubusercontent.com/GTFOBins/GTFOBins.github.io/master/_gtfobins/"
 
 type function struct {
 	Description string `yaml:"description,omitempty"`
@@ -46,7 +46,7 @@ type gtfoStruct struct {
 		FileWrite                  []function `yaml:"file-write"`
 		FileRead                   []function `yaml:"file-read"`
 		LibraryLoad                []function `yaml:"library-load"`
-		Suid                       []function `yaml:"suid"`
+		SUID                       []function `yaml:"suid"`
 		Sudo                       []function `yaml:"sudo"`
 		Capabilities               []function `yaml:"capabilities"`
 		LimitedSuid                []function `yaml:"limited-suid"`

--- a/main.go
+++ b/main.go
@@ -1,23 +1,43 @@
 package main
 
 import (
-	"fmt"
 	"flag"
+	"fmt"
 
 	"github.com/lordlabuckdas/gtfoo/gtfobins"
 )
 
-var gtfoSearch, lolbasSearch string
+// var gtfoSearch, lolbasSearch string
+var gtfoSearch string
 
 func init() {
 	flag.StringVar(&gtfoSearch, "gtfo", "", "gtfobin search term")
 	flag.StringVar(&gtfoSearch, "g", "", "gtfobin search term (shorthand flag)")
-	flag.StringVar(&lolbasSearch, "lolbas", "", "lolbas search term")
-	flag.StringVar(&lolbasSearch, "l", "", "lolbas search term (shorthand flag)")
+	// flag.StringVar(&lolbasSearch, "lolbas", "", "lolbas search term")
+	// flag.StringVar(&lolbasSearch, "l", "", "lolbas search term (shorthand flag)")
 	flag.Parse()
 }
 
 func main() {
-	gtfobins.GtfobinMain(gtfoSearch)
-	fmt.Printf("\n%s", gtfobins.Sudo())
+	if len(gtfoSearch) == 0 {
+		fmt.Print("No search query entered!")
+	} else {
+		gtfobins.GtfobinMain(gtfoSearch)
+		fmt.Print("\n")
+		fmt.Print(gtfobins.Sudo())
+		fmt.Print(gtfobins.Shell())
+		fmt.Print(gtfobins.Command())
+		fmt.Print(gtfobins.ReverseShell())
+		fmt.Print(gtfobins.NonInteractiveReverseShell())
+		fmt.Print(gtfobins.BindShell())
+		fmt.Print(gtfobins.NonInteractiveBindShell())
+		fmt.Print(gtfobins.FileUpload())
+		fmt.Print(gtfobins.FileDownload())
+		fmt.Print(gtfobins.FileWrite())
+		fmt.Print(gtfobins.FileRead())
+		fmt.Print(gtfobins.LibraryLoad())
+		fmt.Print(gtfobins.SUID())
+		fmt.Print(gtfobins.Capabilities())
+		fmt.Print(gtfobins.LimitedSuid())
+	}
 }


### PR DESCRIPTION
**Checks:**

* [x] I have run `go fmt ./...`

* [x] I have run `go mod tidy` inside the directories of all modules

* [x] I have followed **camelCase** and **PascalCase** throughout my code

**PR Content:**

* considered `fmt.Println` followed by `os.Exit` to be a better alternative to `log.Fatalf` (extra info in the latter)

* maybe, later if we are bored, we can customize to non-conflicting exit codes

* changed variable names to uncool *camelCase* from the superior *ALL_CAPS*

* added all print function calls from `main.go`
